### PR TITLE
Use documentElement.clientWidth instead of window.innerWidth

### DIFF
--- a/src/RelativePortal.js
+++ b/src/RelativePortal.js
@@ -71,7 +71,7 @@ export default class RelativePortal extends React.Component {
         const rect = this.element.getBoundingClientRect();
         const pageOffset = getPageOffset();
         const top = pageOffset.y + rect.top;
-        const right = window.innerWidth - rect.right - pageOffset.x;
+        const right = document.documentElement.clientWidth - rect.right - pageOffset.x;
         const left = pageOffset.x + rect.left;
 
         if (top !== this.state.top || left !== this.state.left || right !== this.state.right) {


### PR DESCRIPTION
`window.innerWidth` does not take into account the browser's scrollbar, so may lead to an incorrect position of the component. This PR replaces it with `document.documentElement.clientWidth`.