### PR TITLE
Replace deprecated 'mousewheel' with 'wheel'

### DIFF
--- a/src/RelativePortal.js
+++ b/src/RelativePortal.js
@@ -22,7 +22,7 @@ function getPageOffset() {
 }
 
 function initDOMListener() {
-  document.body.addEventListener('mousewheel', throttle(fireListeners, 100, {
+  document.body.addEventListener('wheel', throttle(fireListeners, 100, {
     leading: true,
     trailing: true,
   }));


### PR DESCRIPTION
According to MDN: https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event

The `mousewheel` event has been deprecated in favor of `wheel`.

The effect of this change is adding support for Firefox which has never supported `mousewheel`.

Tested on Chrome 80.0.3987.149 and Firefox 74.0.1.